### PR TITLE
Make use of available tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - travis_retry composer install
 
 script:
-  - vendor/bin/phpspec run
+  - composer test
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar


### PR DESCRIPTION
Dropped concrete test runner call in favor of `composer test`.
