### PR TITLE
Fixes #10 - Changed from array_reduce to a for-loop to avoid warnings…

### DIFF
--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -49,6 +49,9 @@ class Pipeline implements PipelineInterface
             return $stage->process($payload);
         };
 
-        return array_reduce($this->stages, $reducer, $payload);
+        foreach ($this->stages as $stage) {
+            $payload = $reducer($payload, $stage);
+        }
+        return $payload;
     }
 }


### PR DESCRIPTION
… when Exceptions are thrown inside a stage process.

This change fixes the warning and the phpspec tests still passes but I'm not sure if this change cause any behaviour changes that I haven't thought about and are not covered with the tests(?). Or if there are any other downsides with this change.
