### PR TITLE
Allow stages to interrupt the pipeline by returning null

### DIFF
--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -46,7 +46,7 @@ class Pipeline implements PipelineInterface
     public function process($payload)
     {
         $reducer = function ($payload, StageInterface $stage) {
-            return $stage->process($payload);
+            return $payload === null ? null : $stage->process($payload);
         };
 
         return array_reduce($this->stages, $reducer, $payload);


### PR DESCRIPTION
Only calls the next stage, when the payload is not `null`. This allows to create stages, that can interrupt the processing of the pipeline, for example when the current payload is not sufficient to proceed.

``` php
$result = $pipeline->process($partialData);
// $result === null
// Some other stuff
$result = $pipeline->process($remainingData);
// $result is the result of the entire pipeline
```

This implies a minor BC-break: It is not possible to push `null` forward to the next stage anymore.

Another possible approaches:
- Use a dedicated null-object instead (`class NoResult {}` or something like that). This would avoid the `null` return value from `process()`, but still doesn't prevent one from checking the return value at least as long as there is an interrupting stage within the pipeline
- Use a dedicated exception, like `InterruptedException`. This felt dirty to me, but allows to pass the handling of the interrupt to the caller (depending on the implementation) and again avoids the `null` return value.

Please tell me, whether or not interruptable pipelines fits into this library, or when you'd prefer a different approach.
