### PR TITLE
simplify syntax for adding stages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": ">=5.5"
+        "php": ">=5.6"
     },
     "scripts": {
         "test": "phpspec run"

--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -63,4 +63,9 @@ class Pipeline implements PipelineInterface
     {
         return $this->process($payload);
     }
+
+    public function __call($name, $arguments)
+    {
+        return $this->pipe(new $name(...$arguments));
+    }
 }


### PR DESCRIPTION
Adding `__call` method to Pipeline allows for a simplified syntax for adding Stages. For example:

```
$pipe = (new Pipeline())->StageOne()->StageTwo(10);
```

The name of the class (implementation of StageInterface) to add is simply provided as the method name, then `__call` does the magic of newing it up and calling `->pipe()`.

NB: composer.json updated as variadic operator requires PHP 5.6
