### PR TITLE
Fixed typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ class AddOneStage implements StageInterface
 }
 
 $pipeline = (new Pipeline)
-    ->pipe(new TimeTwoStage)
+    ->pipe(new TimesTwoStage)
     ->pipe(new AddOneStage);
 
 // Returns 21


### PR DESCRIPTION
Class `TimesTwoStage` was misspelled as `TimeTwoStage` in the `pipe()` call, resulting in a missing class fatal error.
