### PR TITLE
Fix example typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ class AddOneStage implements StageInterface
 }
 
 $pipeline = (new Pipeline)
-    ->pipe(new TimeTwoStage)
+    ->pipe(new TimesTwoStage)
     ->pipe(new AddOneStage);
 
 // Returns 21


### PR DESCRIPTION
Just fix a small typo in the class name in readme example
