### PR TITLE
Improve/processor usage

### DIFF
--- a/src/InterruptibleProcessor.php
+++ b/src/InterruptibleProcessor.php
@@ -27,12 +27,9 @@ class InterruptibleProcessor implements ProcessorInterface
      */
     public function process(array $stages, $payload)
     {
-        $check = $this->check;
-
         foreach ($stages as $stage) {
-            $payload = $stage($payload);
-
-            if ($check($payload) !== true) {
+            $payload = call_user_func($stage, $payload);
+            if (true !== call_user_func($this->check, $payload)) {
                 return $payload;
             }
         }

--- a/src/PipelineBuilder.php
+++ b/src/PipelineBuilder.php
@@ -24,10 +24,14 @@ class PipelineBuilder
     }
 
     /**
+     * Build a new Pipeline object
+     *
+     * @param  ProcessorInterface $processor
+     *
      * @return Pipeline
      */
-    public function build()
+    public function build(ProcessorInterface $processor = null)
     {
-        return new Pipeline($this->stages);
+        return new Pipeline($this->stages, $processor);
     }
 }


### PR DESCRIPTION
- using `call_user_func` for `InterruptibleProcessor`
-  Adding `ProcessorInterface` argument to `PipelineBuilder::build` call
