### PR TITLE
Adding Support for Variadic Arguments. Deprecating support for PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
@@ -29,5 +28,4 @@ script:
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.xml; fi
   - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.xml; fi

--- a/README.md
+++ b/README.md
@@ -93,6 +93,27 @@ $pipeline = (new Pipeline)
 $pipeline->process(10);
 ```
 
+## Variadic arguments
+
+Using variadic arguments, it is possible to pass an unlimited number of extra
+arguments to each stage, along with the $payload.
+```
+$stage1 = function( $payload, $param1, $param2 ) {
+    // process the payload using the additional params
+};
+
+$stage2 = function( $payload, $param1, $param2 ) {
+    // process the payload using the additional params
+};
+
+$pipeline = (new Pipeline)
+    ->pipe($stage1)
+    ->pipe($stage2);
+
+$pipeline->process( $payload, $var1, $var2 );
+
+```
+
 ## Re-usable Pipelines
 
 Because the PipelineInterface is an extension of the StageInterface
@@ -106,12 +127,12 @@ something along these lines:
 $processApiRequest = (new Pipeline)
     ->pipe(new ExecuteHttpRequest) // 2
     ->pipe(new ParseJsonResponse); // 3
-    
+
 $pipeline = (new Pipeline)
     ->pipe(new ConvertToPsr7Request) // 1
     ->pipe($processApiRequest) // (2,3)
-    ->pipe(new ConvertToResponseDto); // 4 
-    
+    ->pipe(new ConvertToResponseDto); // 4
+
 $pipeline->process(new DeleteBlogPost($postId));
 ```
 
@@ -147,7 +168,7 @@ pipeline processes a payload.
 $pipeline = (new Pipeline)->pipe(function () {
     throw new LogicException();
 });
-    
+
 try {
     $pipeline->process($payload);
 } catch(LogicException $e) {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": ">=5.5"
+        "php": ">=5.6"
     },
     "scripts": {
         "test": "phpspec run"

--- a/spec/PipelineSpec.php
+++ b/spec/PipelineSpec.php
@@ -37,6 +37,35 @@ class PipelineSpec extends ObjectBehavior
         $this->pipe($operation)->process(1)->shouldBe(2);
     }
 
+    function it_should_process_a_payload_with_params()
+    {
+        $prefix_operation = function ( $strings, $prefix, $suffix ) {
+            return array_map( function( $string ) use ( $prefix ) {
+                return "{$prefix}{$string}";
+            }, $strings );
+        };
+
+        $suffix_operation = function ( $strings, $prefix, $suffix ) {
+            return array_map( function( $string ) use ( $suffix ) {
+                return "{$string}{$suffix}";
+            }, $strings );
+        };
+
+        $payload = [
+            'test value 1',
+            'test value 2',
+            'test value 3',
+        ];
+
+        $expected = [
+            '<test value 1>',
+            '<test value 2>',
+            '<test value 3>',
+        ];
+
+        $this->pipe($prefix_operation)->pipe($suffix_operation)->process($payload,'<','>')->shouldBe($expected);
+    }
+
     function it_should_execute_operations_in_sequence()
     {
         $this->beConstructedWith([

--- a/src/FingersCrossedProcessor.php
+++ b/src/FingersCrossedProcessor.php
@@ -5,15 +5,12 @@ namespace League\Pipeline;
 class FingersCrossedProcessor implements ProcessorInterface
 {
     /**
-     * @param array $stages
-     * @param mixed $payload
-     *
-     * @return mixed
+     * {@inheritdoc}
      */
-    public function process(array $stages, $payload)
+    public function process(array $stages, $payload, ...$params)
     {
         foreach ($stages as $stage) {
-            $payload = call_user_func($stage, $payload);
+            $payload = call_user_func($stage, $payload, ...$params);
         }
 
         return $payload;

--- a/src/InterruptibleProcessor.php
+++ b/src/InterruptibleProcessor.php
@@ -20,17 +20,14 @@ class InterruptibleProcessor implements ProcessorInterface
     }
 
     /**
-     * @param array $stages
-     * @param mixed $payload
-     *
-     * @return mixed
+     * {@inheritdoc}
      */
-    public function process(array $stages, $payload)
+    public function process(array $stages, $payload, ...$params)
     {
         foreach ($stages as $stage) {
-            $payload = call_user_func($stage, $payload);
+            $payload = call_user_func($stage, $payload, ...$params);
 
-            if (true !== call_user_func($this->check, $payload)) {
+            if (true !== call_user_func($this->check, $payload, ...$params)) {
                 return $payload;
             }
         }

--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -37,7 +37,7 @@ class Pipeline implements PipelineInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function pipe(callable $stage)
     {
@@ -48,22 +48,18 @@ class Pipeline implements PipelineInterface
     }
 
     /**
-     * Process the payload.
-     *
-     * @param $payload
-     *
-     * @return mixed
+     * {@inheritdoc}
      */
-    public function process($payload)
+    public function process($payload, ...$params)
     {
-        return $this->processor->process($this->stages, $payload);
+        return $this->processor->process($this->stages, $payload, ...$params);
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
-    public function __invoke($payload)
+    public function __invoke($payload, ...$params)
     {
-        return $this->process($payload);
+        return $this->process($payload, ...$params);
     }
 }

--- a/src/PipelineInterface.php
+++ b/src/PipelineInterface.php
@@ -7,9 +7,19 @@ interface PipelineInterface extends StageInterface
     /**
      * Create a new pipeline with an appended stage.
      *
-     * @param callable $operation
+     * @param callable $stage
      *
      * @return static
      */
-    public function pipe(callable $operation);
+    public function pipe(callable $stage);
+
+    /**
+     * Process the payload
+     *
+     * @param mixed $payload
+     * @param mixed ...$params
+     *
+     * @return mixed
+     */
+    public function process($payload, ...$params);
 }

--- a/src/ProcessorInterface.php
+++ b/src/ProcessorInterface.php
@@ -5,10 +5,11 @@ namespace League\Pipeline;
 interface ProcessorInterface
 {
     /**
-     * @param array $stages
-     * @param mixed $payload
+     * @param callable[] $stages
+     * @param mixed      $payload
+     * @param mixed      ...$params
      *
      * @return mixed
      */
-    public function process(array $stages, $payload);
+    public function process(array $stages, $payload, ...$params);
 }

--- a/src/StageInterface.php
+++ b/src/StageInterface.php
@@ -5,11 +5,12 @@ namespace League\Pipeline;
 interface StageInterface
 {
     /**
-     * Process the payload.
+     * Process the payload
      *
      * @param mixed $payload
+     * @param mixed ...$params
      *
      * @return mixed
      */
-    public function __invoke($payload);
+    public function __invoke($payload, ...$params);
 }

--- a/stub/StubStage.php
+++ b/stub/StubStage.php
@@ -9,13 +9,9 @@ class StubStage implements StageInterface
     const STUBBED_RESPONSE = 'stubbed response';
 
     /**
-     * Process the payload.
-     *
-     * @param mixed $payload
-     *
-     * @return mixed
+     * @inheritdoc
      */
-    public function __invoke($payload)
+    public function __invoke($payload, ...$params)
     {
         return self::STUBBED_RESPONSE;
     }


### PR DESCRIPTION
Following on https://github.com/thephpleague/pipeline/issues/18, this PR adds support for Variadic functions to be used as with the pipeline.

Unfortunately, this would require to drop support for PHP 5.5, as this feature is only available on 5.6+.