### PR TITLE
Update for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,16 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
-  - hhvm
-
-sudo: false
+  - 7.2
 
 cache:
+
   directories:
     - $HOME/.composer/cache
 
 matrix:
   fast_finish: true
-
-before_install:
-  - if [ "$TRAVIS_PHP_VERSION" == "7.0" ]; then mv phpspec.no-coverage.yml phpspec.yml; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "7.1" ]; then mv phpspec.no-coverage.yml phpspec.yml; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then mv phpspec.no-coverage.yml phpspec.yml; fi
 
 install:
   - travis_retry composer install
@@ -29,5 +20,4 @@ script:
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.xml; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.xml; fi
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 * Now requires PHP 7.1 or newer.
+* Pipeline requires processor as first argument.
 
 ## 0.3.0 - 2016-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Now requires PHP 7.1 or newer.
 * Pipeline requires processor as first argument.
+* Processor requires payload as first argument.
 
 ## 0.3.0 - 2016-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.0 - ???
+
+### Added
+
+* Add strict typing.
+
+### Changed
+
+* Now requires PHP 7.1 or newer.
+
 ## 0.3.0 - 2016-10-13
 
 * A pipeline now has a processor which is responsible for the stage invoking.

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
         }
     },
     "require": {
-        "php": ">=5.5"
+        "php": ">=7.1"
     },
     "scripts": {
         "test": "phpspec run"
     },
     "require-dev": {
-        "phpspec/phpspec": "^2.2",
-        "henrikbjorn/phpspec-code-coverage": "^1.0"
+        "phpspec/phpspec": "^4.3",
+        "leanphp/phpspec-code-coverage": "^4.2"
     }
 }

--- a/phpspec.no-coverage.yml
+++ b/phpspec.no-coverage.yml
@@ -1,5 +1,0 @@
----
-suites:
-    pipeline_suite:
-        namespace: League\Pipeline
-        psr4_prefix: League\Pipeline

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -3,8 +3,9 @@ suites:
     pipeline_suite:
         namespace: League\Pipeline
         psr4_prefix: League\Pipeline
+
 extensions:
-    - PhpSpec\Extension\CodeCoverageExtension
+    LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension: ~
 
 code_coverage:
     format:

--- a/spec/FingersCrossedProcessorSpec.php
+++ b/spec/FingersCrossedProcessorSpec.php
@@ -15,8 +15,9 @@ class FingersCrossedProcessorSpec extends ObjectBehavior
 
     function it_should_process_stages()
     {
-        $this->process([
+        $this->process(
+            2,
             function ($payload) { return $payload * 2; }
-        ], 2)->shouldBe(4);
+        )->shouldBe(4);
     }
 }

--- a/spec/InterruptibleProcessorSpec.php
+++ b/spec/InterruptibleProcessorSpec.php
@@ -21,14 +21,16 @@ class InterruptibleProcessorSpec extends ObjectBehavior
 
     function it_should_interrupt()
     {
-        $this->process([
+        $this->process(
+            5,
             function ($payload) { return $payload + 2; },
             function ($payload) { return $payload * 10; },
-            function ($payload) { return $payload * 10; },
-        ], 5)->shouldBe(70);
+            function ($payload) { return $payload * 10; }
+        )->shouldBe(70);
 
-        $this->process([
-            function ($payload) { return $payload + 2; },
-        ], 5)->shouldBe(7);
+        $this->process(
+            5,
+            function ($payload) { return $payload + 2; }
+        )->shouldBe(7);
     }
 }

--- a/spec/PipelineBuilderSpec.php
+++ b/spec/PipelineBuilderSpec.php
@@ -14,11 +14,6 @@ class PipelineBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PipelineBuilder::class);
     }
 
-    function it_should_build_a_pipeline()
-    {
-        $this->build()->shouldHaveType(PipelineInterface::class);
-    }
-
     function it_should_collect_operations_for_a_pipeline()
     {
         $this->add(function ($p) {

--- a/spec/PipelineSpec.php
+++ b/spec/PipelineSpec.php
@@ -38,17 +38,13 @@ class PipelineSpec extends ObjectBehavior
 
     function it_should_execute_operations_in_sequence()
     {
-        $this->beConstructedWith([
+        $this->beConstructedWith(
+            null,
             function ($p) { return $p + 2; },
-            function ($p) { return $p * 10; },
-        ]);
+            function ($p) { return $p * 10; }
+        );
 
         $this->__invoke(1)->shouldBe(30);
-    }
-
-    function it_should_only_allow_operations_as_constructor_arguments()
-    {
-        $this->shouldThrow(InvalidArgumentException::class)->during('__construct', [['fooBar']]);
     }
 
     function it_should_accept_implementations_of_stage()

--- a/spec/PipelineSpec.php
+++ b/spec/PipelineSpec.php
@@ -21,7 +21,6 @@ class PipelineSpec extends ObjectBehavior
     function it_should_pipe_operation()
     {
         $operation = function () {};
-        $this->pipe($operation)->shouldHaveType(PipelineInterface::class);
         $this->pipe($operation)->shouldNotBe($this);
     }
 

--- a/src/FingersCrossedProcessor.php
+++ b/src/FingersCrossedProcessor.php
@@ -5,10 +5,10 @@ namespace League\Pipeline;
 
 class FingersCrossedProcessor implements ProcessorInterface
 {
-    public function process(array $stages, $payload)
+    public function process($payload, callable ...$stages)
     {
         foreach ($stages as $stage) {
-            $payload = call_user_func($stage, $payload);
+            $payload = $stage($payload);
         }
 
         return $payload;

--- a/src/FingersCrossedProcessor.php
+++ b/src/FingersCrossedProcessor.php
@@ -1,15 +1,10 @@
 <?php
+declare(strict_types=1);
 
 namespace League\Pipeline;
 
 class FingersCrossedProcessor implements ProcessorInterface
 {
-    /**
-     * @param array $stages
-     * @param mixed $payload
-     *
-     * @return mixed
-     */
     public function process(array $stages, $payload)
     {
         foreach ($stages as $stage) {

--- a/src/InterruptibleProcessor.php
+++ b/src/InterruptibleProcessor.php
@@ -15,12 +15,14 @@ class InterruptibleProcessor implements ProcessorInterface
         $this->check = $check;
     }
 
-    public function process(array $stages, $payload)
+    public function process($payload, callable ...$stages)
     {
-        foreach ($stages as $stage) {
-            $payload = call_user_func($stage, $payload);
+        $check = $this->check;
 
-            if (true !== call_user_func($this->check, $payload)) {
+        foreach ($stages as $stage) {
+            $payload = $stage($payload);
+
+            if (true !== $check($payload)) {
                 return $payload;
             }
         }

--- a/src/InterruptibleProcessor.php
+++ b/src/InterruptibleProcessor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace League\Pipeline;
 
@@ -9,22 +10,11 @@ class InterruptibleProcessor implements ProcessorInterface
      */
     private $check;
 
-    /**
-     * InterruptibleProcessor constructor.
-     *
-     * @param callable $check
-     */
     public function __construct(callable $check)
     {
         $this->check = $check;
     }
 
-    /**
-     * @param array $stages
-     * @param mixed $payload
-     *
-     * @return mixed
-     */
     public function process(array $stages, $payload)
     {
         foreach ($stages as $stage) {

--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace League\Pipeline;
 
@@ -17,10 +18,7 @@ class Pipeline implements PipelineInterface
     private $processor;
 
     /**
-     * Constructor.
-     *
-     * @param callable[]         $stages
-     * @param ProcessorInterface $processor
+     * @param callable[] $stages
      *
      * @throws InvalidArgumentException
      */
@@ -33,13 +31,10 @@ class Pipeline implements PipelineInterface
         }
 
         $this->stages = $stages;
-        $this->processor = $processor ?: new FingersCrossedProcessor;
+        $this->processor = $processor ?? new FingersCrossedProcessor;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function pipe(callable $stage)
+    public function pipe(callable $stage): PipelineInterface
     {
         $pipeline = clone $this;
         $pipeline->stages[] = $stage;
@@ -47,21 +42,11 @@ class Pipeline implements PipelineInterface
         return $pipeline;
     }
 
-    /**
-     * Process the payload.
-     *
-     * @param $payload
-     *
-     * @return mixed
-     */
     public function process($payload)
     {
         return $this->processor->process($this->stages, $payload);
     }
 
-    /**
-     * @inheritdoc
-     */
     public function __invoke($payload)
     {
         return $this->process($payload);

--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -31,7 +31,7 @@ class Pipeline implements PipelineInterface
 
     public function process($payload)
     {
-        return $this->processor->process($this->stages, $payload);
+        return $this->processor->process($payload, ...$this->stages);
     }
 
     public function __invoke($payload)

--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace League\Pipeline;
 
-use InvalidArgumentException;
-
 class Pipeline implements PipelineInterface
 {
     /**
@@ -17,21 +15,10 @@ class Pipeline implements PipelineInterface
      */
     private $processor;
 
-    /**
-     * @param callable[] $stages
-     *
-     * @throws InvalidArgumentException
-     */
-    public function __construct(array $stages = [], ProcessorInterface $processor = null)
+    public function __construct(ProcessorInterface $processor = null, callable ...$stages)
     {
-        foreach ($stages as $stage) {
-            if (false === is_callable($stage)) {
-                throw new InvalidArgumentException('All stages should be callable.');
-            }
-        }
-
-        $this->stages = $stages;
         $this->processor = $processor ?? new FingersCrossedProcessor;
+        $this->stages = $stages;
     }
 
     public function pipe(callable $stage): PipelineInterface

--- a/src/PipelineBuilder.php
+++ b/src/PipelineBuilder.php
@@ -22,6 +22,6 @@ class PipelineBuilder implements PipelineBuilderInterface
 
     public function build(ProcessorInterface $processor = null): PipelineInterface
     {
-        return new Pipeline($this->stages, $processor);
+        return new Pipeline($processor, ...$this->stages);
     }
 }

--- a/src/PipelineBuilder.php
+++ b/src/PipelineBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace League\Pipeline;
 
@@ -10,27 +11,16 @@ class PipelineBuilder implements PipelineBuilderInterface
     private $stages = [];
 
     /**
-     * Add an stage.
-     *
-     * @param callable $stage
-     *
-     * @return $this
+     * @return self
      */
-    public function add(callable $stage)
+    public function add(callable $stage): PipelineBuilderInterface
     {
         $this->stages[] = $stage;
 
         return $this;
     }
 
-    /**
-     * Build a new Pipeline object
-     *
-     * @param  ProcessorInterface|null $processor
-     *
-     * @return PipelineInterface
-     */
-    public function build(ProcessorInterface $processor = null)
+    public function build(ProcessorInterface $processor = null): PipelineInterface
     {
         return new Pipeline($this->stages, $processor);
     }

--- a/src/PipelineBuilderInterface.php
+++ b/src/PipelineBuilderInterface.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace League\Pipeline;
 
 interface PipelineBuilderInterface
@@ -6,18 +8,12 @@ interface PipelineBuilderInterface
     /**
      * Add an stage.
      *
-     * @param callable $stage
-     *
-     * @return $this
+     * @return self
      */
-    public function add(callable $stage);
+    public function add(callable $stage): PipelineBuilderInterface;
 
     /**
-     * Build a new Pipeline object
-     *
-     * @param  ProcessorInterface|null $processor
-     *
-     * @return PipelineInterface
+     * Build a new Pipeline object.
      */
-    public function build(ProcessorInterface $processor = null);
+    public function build(ProcessorInterface $processor = null): PipelineInterface;
 }

--- a/src/PipelineInterface.php
+++ b/src/PipelineInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace League\Pipeline;
 
@@ -7,9 +8,7 @@ interface PipelineInterface extends StageInterface
     /**
      * Create a new pipeline with an appended stage.
      *
-     * @param callable $operation
-     *
      * @return static
      */
-    public function pipe(callable $operation);
+    public function pipe(callable $operation): PipelineInterface;
 }

--- a/src/ProcessorInterface.php
+++ b/src/ProcessorInterface.php
@@ -6,10 +6,11 @@ namespace League\Pipeline;
 interface ProcessorInterface
 {
     /**
-     * @param array $stages
+     * Process the payload using multiple stages.
+     *
      * @param mixed $payload
      *
      * @return mixed
      */
-    public function process(array $stages, $payload);
+    public function process($payload, callable ...$stages);
 }

--- a/src/ProcessorInterface.php
+++ b/src/ProcessorInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace League\Pipeline;
 

--- a/src/StageInterface.php
+++ b/src/StageInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace League\Pipeline;
 


### PR DESCRIPTION
Adds strict typing and makes a couple of modifications for better type checking:

- `Pipeline::__construct` argument order changed to use variadic.
- `Processor::process` argument order changed to use variadic.

Also upgrades to latest phpspec and switches to a supported code coverage extension.