### PR TITLE
Pass any variables between stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /coverage/
 /coverage.xml
+.idea

--- a/src/FingersCrossedProcessor.php
+++ b/src/FingersCrossedProcessor.php
@@ -3,12 +3,14 @@ declare(strict_types=1);
 
 namespace League\Pipeline;
 
-class FingersCrossedProcessor implements ProcessorInterface
+class FingersCrossedProcessor implements ProcessorInterface, ParametersInterface
 {
+    use ParametersTrait;
+
     public function process($payload, callable ...$stages)
     {
         foreach ($stages as $stage) {
-            $payload = $stage($payload);
+            $payload = $stage($payload, ...$this->getParameters());
         }
 
         return $payload;

--- a/src/InterruptibleProcessor.php
+++ b/src/InterruptibleProcessor.php
@@ -3,8 +3,10 @@ declare(strict_types=1);
 
 namespace League\Pipeline;
 
-class InterruptibleProcessor implements ProcessorInterface
+class InterruptibleProcessor implements ProcessorInterface, ParametersInterface
 {
+    use ParametersTrait;
+
     /**
      * @var callable
      */
@@ -20,7 +22,7 @@ class InterruptibleProcessor implements ProcessorInterface
         $check = $this->check;
 
         foreach ($stages as $stage) {
-            $payload = $stage($payload);
+            $payload = $stage($payload, ...$this->getParameters());
 
             if (true !== $check($payload)) {
                 return $payload;

--- a/src/ParametersInterface.php
+++ b/src/ParametersInterface.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace League\Pipeline;
+
+interface ParametersInterface
+{
+    /**
+     * Get parameters for each stage.
+     *
+     * @return array
+     */
+    public function getParameters();
+
+    /**
+     * Set parameters for each stage.
+     *
+     * @param array $params
+     *
+     * @return void
+     */
+    public function setParameters(...$params);
+}

--- a/src/ParametersTrait.php
+++ b/src/ParametersTrait.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace League\Pipeline;
+
+trait ParametersTrait
+{
+    /**
+     * @var array
+     */
+    protected $parameters = [];
+
+    /**
+     * Get parameters for each stage.
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * Set parameters for each stage.
+     *
+     * @param array $params
+     * @return void
+     */
+    public function setParameters(...$params)
+    {
+        $this->parameters = $params;
+    }
+}

--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -15,12 +15,24 @@ class Pipeline implements PipelineInterface
      */
     private $processor;
 
+    /**
+     * Pipeline constructor.
+     *
+     * @param \League\Pipeline\ProcessorInterface|null $processor
+     * @param callable ...$stages
+     */
     public function __construct(ProcessorInterface $processor = null, callable ...$stages)
     {
         $this->processor = $processor ?? new FingersCrossedProcessor;
         $this->stages = $stages;
     }
 
+    /**
+     * One pipe for your task.
+     *
+     * @param callable $stage
+     * @return \League\Pipeline\PipelineInterface|$this
+     */
     public function pipe(callable $stage): PipelineInterface
     {
         $pipeline = clone $this;
@@ -29,13 +41,18 @@ class Pipeline implements PipelineInterface
         return $pipeline;
     }
 
-    public function process($payload)
+    public function process($payload, ...$params)
     {
+        if ($this->processor instanceof ParametersInterface) {
+            $this->processor->setParameters(...$params);
+            return $this->processor->process($payload, ...$this->stages);
+        }
+
         return $this->processor->process($payload, ...$this->stages);
     }
 
-    public function __invoke($payload)
+    public function __invoke($payload, ...$params)
     {
-        return $this->process($payload);
+        return $this->process($payload, ...$params);
     }
 }

--- a/src/ProcessorInterface.php
+++ b/src/ProcessorInterface.php
@@ -9,6 +9,7 @@ interface ProcessorInterface
      * Process the payload using multiple stages.
      *
      * @param mixed $payload
+     * @param callable[] $stages
      *
      * @return mixed
      */


### PR DESCRIPTION
Work example:

```php
require __DIR__ . '/vendor/autoload.php';

use League\Pipeline\Pipeline;

$pipeline = (new Pipeline)
    ->pipe(function ($payload, $dto) {
        $dto['ten'] = 10;
        return $payload * 2;
    })
    ->pipe(function ($payload, $dto) {
        return $payload + $dto['ten'];
    });

echo $pipeline->process(5, new ArrayObject());
// 20
```

Also I added docblocks for better IDE autocomplete. Full backward compatibility.