### PR TITLE
Fixed autocomplete.

### DIFF
--- a/src/PipelineInterface.php
+++ b/src/PipelineInterface.php
@@ -11,4 +11,13 @@ interface PipelineInterface extends StageInterface
      * @return static
      */
     public function pipe(callable $operation): PipelineInterface;
+
+    /**
+     * Process the payload.
+     *
+     * @param mixed $payload
+     *
+     * @return mixed
+     */
+    public function process($payload);
 }


### PR DESCRIPTION
I've added autocomplete for the `process()` method for Pipeline. Useful after calling `build()` from the PipelineBuilder. 