### PR TITLE
Add tested support to PHP 7.3 and 7.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 /vendor/
 /composer.lock
 /coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 cache:
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "test": "phpspec run"
     },
     "require-dev": {
-        "phpspec/phpspec": "^4.3",
-        "leanphp/phpspec-code-coverage": "^4.2"
+        "phpspec/phpspec": "^7.0",
+        "friends-of-phpspec/phpspec-code-coverage": "^6.0"
     }
 }


### PR DESCRIPTION
# Improvements done
- bumped `phpspec/phpspec` to version 7
- migrated `phpspec-code-coverage` from the abandoned `leanphp/phpspec-code-coverage` to `friends-of-phpspec/phpspec-code-coverage`
- bumped `phpspec-code-coverage` to version 6
- added PHP 7.3 and PHP 7.4 on Travis automated test coverages