### PR TITLE
Add github action to test against PHP 7.2 - 8.2

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -1,0 +1,41 @@
+---
+name: Quality Assurance
+on:
+  push:
+    paths:
+      - src/**/*.php
+      - composer.json
+      - .github/workflows/quality-assurance.yml
+    branches:
+      - master
+      - main
+  pull_request:
+    paths:
+      - src/**/*.php
+      - composer.json
+      - .github/workflows/quality-assurance.yml
+    branches:
+      - master
+      - main
+
+jobs:
+  phpunit:
+    name: PHPUnit tests on ${{ matrix.php }} ${{ matrix.composer-flags }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        composer-flags: [ '' ]
+        experimental: [false]
+        phpunit-flags: [ '--coverage-text' ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: pcov
+          tools: composer:v2
+      - run: composer update --no-progress ${{ matrix.composer-flags }}
+      - run: composer test

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "test": "phpspec run"
     },
     "require-dev": {
-        "phpspec/phpspec": "^4.3",
-        "leanphp/phpspec-code-coverage": "^4.2"
+        "phpspec/phpspec": ">=4.3",
+        "friends-of-phpspec/phpspec-code-coverage": ">=4.3"
     }
 }

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -5,7 +5,7 @@ suites:
         psr4_prefix: League\Pipeline
 
 extensions:
-    LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension: ~
+    FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension: ~
 
 code_coverage:
     format:


### PR DESCRIPTION
This project hasn't seen much love but nonetheless it works.
Therefore to show the world that it should work on the latest PHP version (but also older, already unsupported like 7.2) this PR adds some automatic testing via github actions.